### PR TITLE
Add link to docs repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,6 @@
 
 The repository is for feedback on the [Atom.io website](https://atom.io) and the [package API](https://github.com/atom/atom/blob/master/docs/apm-rest-api.md) used by [apm](https://github.com/atom/apm). Have something to suggest or a bug to report? [Take a look at the issues on this repo](https://github.com/atom/atom.io/issues) and see if there's already a discussion going, otherwise [file a new issue](https://github.com/atom/atom.io/issues/new) and get the conversation started.
 
+For issues on the documentation, see [atom/docs](https://github.com/atom/docs).
+
 ![](https://atom.io/assets/open-source@2x-36b4d5d617f174eaafb310682263dfa0.jpg)


### PR DESCRIPTION
Since the docs are hosted on the atom.io site, I mistakenly submitted an issue to this repo instead of the docs site. Adding this information would help with that.
