### PR TITLE
Fix link to the Flight Manual and fix the picture in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ The repository is for feedback on the [Atom.io website](https://atom.io) and the
 
 For issues with the documentation from the [Atom Flight Manual](http://flight-manual.atom.io/), see [atom/flight-manual.atom.io](https://github.com/atom/flight-manual.atom.io).
 
-![](https://github-atom-io-herokuapp-com.global.ssl.fastly.net/assets/open-source-f44fe3a70a514e2aaec10a2c34300bb5.jpg)
+![](https://cloud.githubusercontent.com/assets/69169/7661190/60a6a044-fb05-11e4-8674-bf31d9f8b66f.jpg)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 The repository is for feedback on the [Atom.io website](https://atom.io) and the [package API](https://github.com/atom/atom/blob/master/docs/apm-rest-api.md) used by [apm](https://github.com/atom/apm). Have something to suggest or a bug to report? [Take a look at the issues on this repo](https://github.com/atom/atom.io/issues) and see if there's already a discussion going, otherwise [file a new issue](https://github.com/atom/atom.io/issues/new) and get the conversation started.
 
-For issues with the documentation from [Atom Flight Manual](https://atom.io/docs/latest/), see [atom/docs](https://github.com/atom/docs).
+For issues with the documentation from the [Atom Flight Manual](http://flight-manual.atom.io/), see [atom/flight-manual.atom.io](https://github.com/atom/flight-manual.atom.io).
 
-![](https://atom.io/assets/open-source@2x-36b4d5d617f174eaafb310682263dfa0.jpg)
+![](https://github-atom-io-herokuapp-com.global.ssl.fastly.net/assets/open-source-f44fe3a70a514e2aaec10a2c34300bb5.jpg)


### PR DESCRIPTION
I've updated the `README` to link to the Flight Manual in a better way, and fixed the 'Open Source' image.