### PR TITLE
Replace "Open Source" image with a screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 The repository is for feedback on the [Atom.io website](https://atom.io) and the [package API](https://github.com/atom/atom/blob/master/docs/apm-rest-api.md) used by [apm](https://github.com/atom/apm). Have something to suggest or a bug to report? [Take a look at the issues on this repo](https://github.com/atom/atom.io/issues) and see if there's already a discussion going, otherwise [file a new issue](https://github.com/atom/atom.io/issues/new) and get the conversation started.
 
-For issues with the documentation from the [Atom Flight Manual](http://flight-manual.atom.io/), see [atom/flight-manual.atom.io](https://github.com/atom/flight-manual.atom.io).
+![atom.io screenshot](https://cloud.githubusercontent.com/assets/378023/16328441/286c318a-3a15-11e6-9ce6-bd4a46e91270.png)
 
-![](https://cloud.githubusercontent.com/assets/69169/7661190/60a6a044-fb05-11e4-8674-bf31d9f8b66f.jpg)
+For issues with the documentation from the [Atom Flight Manual](http://flight-manual.atom.io/), see [atom/flight-manual.atom.io](https://github.com/atom/flight-manual.atom.io).


### PR DESCRIPTION
Follow up of https://github.com/atom/atom.io/pull/76

This replaces the "open source" image with an actual screenshot of atom.io.

[Rendered](https://github.com/atom/atom.io/blob/7fb0319acf5a2e9b639eaf2d9cdc02ad28bfead3/README.md)
